### PR TITLE
Renesas Gen3 revision number fix

### DIFF
--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -214,8 +214,8 @@ bool vr_update_renesas_gen3::isUpdatable()
 
     if (ret >= SUCCESS)
     {
-        DeviceRevision = (rdata[INDEX_1] << SHIFT_24) | (rdata[INDEX_2] << SHIFT_16)
-                                      | (rdata[INDEX_3] << SHIFT_8) | rdata[INDEX_4];
+        DeviceRevision = (rdata[INDEX_4] << SHIFT_24) | (rdata[INDEX_3] << SHIFT_16)
+                                      | (rdata[INDEX_2] << SHIFT_8) | rdata[INDEX_1];
 
         sd_journal_print(LOG_INFO, "Device revision from VR device = 0x%x\n", DeviceRevision);
     }


### PR DESCRIPTION
Renesas GEN3 update has a revision number check before updating the firmware. The endiannes of the revision number was not correct previously. Fixed the endianness so the update will not fail due to revision number mismatch