### PR TITLE
Add fixes for Turin VR update

### DIFF
--- a/config/chalupa-vr.json
+++ b/config/chalupa-vr.json
@@ -59,6 +59,21 @@
          "SlaveAddress":"0x65",
          "Processor":"P1",
          "VrName":"P1_VDD_33_DUAL"
+      },
+      {
+         "SlaveAddress":"0x13",
+         "Processor":"None",
+         "VrName":"VDD_13_RUN"
+      },
+      {
+         "SlaveAddress":"0x14",
+         "Processor":"None",
+         "VrName":"VDD_33_DUAL"
+      },
+      {
+         "SlaveAddress":"0x15",
+         "Processor":"None",
+         "VrName":"VDD_5_DUAL"
       }
    ]
 }

--- a/config/vr-config-info
+++ b/config/vr-config-info
@@ -35,25 +35,25 @@ install_vr_platform_config()
        "59"|"62"|"65")  # Shale board_ids
           cp /usr/sbin/shale-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "102" | "110" | "111") #Chalupa board_ids
+       "66" | "6E" | "6F") #Chalupa board_ids
           cp /usr/sbin/chalupa-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "103") #huambo board_ids
+       "67") #huambo board_ids
           cp /usr/sbin/huambo-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "104" | "112" | "113") #galena board_ids
+       "68" | "70" | "71") #galena board_ids
           cp /usr/sbin/galena-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "105") #recluse board_ids
+       "69") #recluse board_ids
           cp /usr/sbin/recluse-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "106" | "114" | "115") #purico board_ids
+       "6A" | "72" | "73") #purico board_ids
           cp /usr/sbin/purico-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "107" | "116" | "117") #volcano board_ids
+       "6B" | "74" | "75") #volcano board_ids
           cp /usr/sbin/volcano-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "5C" | "5D" | "5E" | "6C" | "6D" |"5F" | "60" ) #volcano board_ids
+       "5C" | "5D" | "5E" | "6C" | "6D" |"5F" | "60" ) #sh5 board_ids
           cp /usr/sbin/sh5-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
        esac

--- a/inc/vr_update_infineon_xdpe.hpp
+++ b/inc/vr_update_infineon_xdpe.hpp
@@ -23,6 +23,8 @@
 #define PART5             (0x99)
 
 /* CMD PREFIX */
+
+#define DEVICE_ID_CMD     (0xad)
 #define RPTR              (0xce)
 #define MFR_REG_WRITE     (0xde)
 #define MFR_REG_READ      (0xdf)

--- a/src/vr_update.cpp
+++ b/src/vr_update.cpp
@@ -130,7 +130,6 @@ bool vr_update::findBusNumber()
         else if(Processor.compare(SOCKET_1) == SUCCESS)
         {
             DeviceName = slaveDevice[INDEX_1];
-            std::cout << DeviceName << std::endl;
             slaveDevice[INDEX_1].resize(INDEX_2);
             BusNumber = std::stoi(slaveDevice[INDEX_1]);
         }

--- a/src/vr_update_infineon_xdpe.cpp
+++ b/src/vr_update_infineon_xdpe.cpp
@@ -86,21 +86,7 @@ bool vr_update_infineon_xdpe::isUpdatable()
     int size;
     int rc = FAILURE;
 
-    /*Find if the VR device is infineon*/
-    wdata[INDEX_0] = DDBD0;
-    wdata[INDEX_1] = DDBD1;
-    wdata[INDEX_2] = DDBD2;
-    wdata[INDEX_3] = DDBD3;
-
-    rc = i2c_smbus_write_block_data(fd, RPTR, (uint8_t)LENGTHOFBLOCK, wdata);
-
-    if (rc != SUCCESS)
-    {
-        sd_journal_print(LOG_ERR, "Error: Failed to write data\n");
-        return false;
-    }
-
-    length = i2c_smbus_read_block_data(fd, MFR_REG_READ, rdata);
+    length = i2c_smbus_read_block_data(fd, DEVICE_ID_CMD, rdata);
 
     if (length > LENGTH_0)
     {
@@ -109,7 +95,7 @@ bool vr_update_infineon_xdpe::isUpdatable()
         {
             sd_journal_print(LOG_INFO, "Infineon device detected\n");
         } else {
-            sd_journal_print(LOG_ERR, "Error: No device detected\n");
+            sd_journal_print(LOG_ERR, "Part number = 0x%x. Error: No device detected\n",rdata[INDEX_1]);
             return false;
         }
     } else {

--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -214,8 +214,8 @@ bool vr_update_renesas_gen3::isUpdatable()
 
     if (ret >= SUCCESS)
     {
-        DeviceRevision = (rdata[INDEX_1] << SHIFT_24) | (rdata[INDEX_2] << SHIFT_16)
-                                      | (rdata[INDEX_3] << SHIFT_8) | rdata[INDEX_4];
+        DeviceRevision = (rdata[INDEX_4] << SHIFT_24) | (rdata[INDEX_3] << SHIFT_16)
+                                      | (rdata[INDEX_2] << SHIFT_8) | rdata[INDEX_1];
 
         sd_journal_print(LOG_INFO, "Device revision from VR device = 0x%x\n", DeviceRevision);
     }


### PR DESCRIPTION
1. Correct board id's of Turin platform to hex values.
2. Add "VDD_13_RUN", "VDD_33_DUAL", "VDD_5_DUAL" to Chalupa platform. 
3. Updated logic to find the device ID for Infineon devices
4. Renesas GEN3 update has a revision number check before updating the firmware. The endiannes of the revision number was not correct previously. Fixed the endianness so the update will not fail due to revision number mismatch.