### PR TITLE
Webui Status messages updated after vr update

### DIFF
--- a/config/chalupa-vr.json
+++ b/config/chalupa-vr.json
@@ -1,24 +1,19 @@
 {
    "VRConfigs":[
       {
-         "SlaveAddress":"0x60",
+         "SlaveAddress":"0x61",
          "Processor":"P0",
          "VrName":"P0_VDD_CORE0_RUN"
       },
       {
-         "SlaveAddress":"0x61",
+         "SlaveAddress":"0x62",
          "Processor":"P0",
          "VrName":"P0_VDD_CORE1_RUN"
       },
       {
-         "SlaveAddress":"0x62",
-         "Processor":"P0",
-         "VrName":"P0_VDD_IO_RUN"
-      },
-      {
          "SlaveAddress":"0x63",
          "Processor":"P0",
-         "VrName":"P0_VDD_11_SUS"
+         "VrName":"P0_VDD_VDDIO_RUN"
       },
       {
          "SlaveAddress":"0x64",
@@ -31,24 +26,19 @@
          "VrName":"P0_VDD_33_DUAL"
       },
       {
-         "SlaveAddress":"0x60",
+         "SlaveAddress":"0x61",
          "Processor":"P1",
          "VrName":"P1_VDD_CORE0_RUN"
       },
       {
-         "SlaveAddress":"0x61",
+         "SlaveAddress":"0x62",
          "Processor":"P1",
          "VrName":"P1_VDD_CORE1_RUN"
       },
       {
-         "SlaveAddress":"0x62",
-         "Processor":"P1",
-         "VrName":"P1_VDD_IO_RUN"
-      },
-      {
          "SlaveAddress":"0x63",
          "Processor":"P1",
-         "VrName":"P1_VDD_11_SUS"
+         "VrName":"P1_VDDIO_RUN"
       },
       {
          "SlaveAddress":"0x64",

--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -140,7 +140,7 @@ public:
     virtual bool UpdateFirmware() = 0;
     virtual bool crcCheckSum() = 0;
     virtual bool ValidateFirmware() = 0;
-
+    bool CrcMatched;
 };
 
 #endif

--- a/src/vr_update_infineon_tda.cpp
+++ b/src/vr_update_infineon_tda.cpp
@@ -139,11 +139,13 @@ bool vr_update_infineon_tda::crcCheckSum()
     if(DeviceCrcData == Crc)
     {
         sd_journal_print(LOG_ERR, "CRC matches with previous image. Skipping the update\n");
+        CrcMatched = true;
         return false;
     }
     else
     {
         sd_journal_print(LOG_INFO, "CRC didnot match with previous image. Continuing the update\n");
+        CrcMatched = false;
     }
 
 

--- a/src/vr_update_infineon_xdpe.cpp
+++ b/src/vr_update_infineon_xdpe.cpp
@@ -68,11 +68,13 @@ bool vr_update_infineon_xdpe::crcCheckSum()
     if(DeviceCrcData == Crc)
     {
         sd_journal_print(LOG_ERR, "CRC matches with previous image. Skipping the update\n");
+        CrcMatched = true;
         return false;
     }
     else
     {
         sd_journal_print(LOG_ERR, "CRC didnot match with previous image. Continuing the update\n");
+        CrcMatched = false;
     }
     return true;
 }

--- a/src/vr_update_mps.cpp
+++ b/src/vr_update_mps.cpp
@@ -39,11 +39,13 @@ bool vr_update_mps::crcCheckSum(){
     if(DeviceCrc == Crc)
     {
        sd_journal_print(LOG_ERR, "Error: Device CRC matches with file CRC. Skipping the update\n");
+       CrcMatched = true;
        return FAILURE;
     }
     else
     {
         sd_journal_print(LOG_ERR, "Info: CRC does not match with the previous image. Continuing the update\n");
+        CrcMatched = false;
         return SUCCESS;
     }
 }

--- a/src/vr_update_renesas_gen2.cpp
+++ b/src/vr_update_renesas_gen2.cpp
@@ -50,11 +50,13 @@ bool vr_update_renesas_gen2::crcCheckSum()
     if(DeviceCrc == Crc)
     {
        sd_journal_print(LOG_ERR, "Device CRC matches with file CRC. Skipping the update\n");
+       CrcMatched = true;
        return false;
     }
     else
     {
         sd_journal_print(LOG_INFO, "CRC not matched with the previous image. Continuing the update\n");
+        CrcMatched = false;
         return true;
     }
 }

--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -50,11 +50,13 @@ bool vr_update_renesas_gen3::crcCheckSum()
     if(DeviceCrc == Crc)
     {
        sd_journal_print(LOG_ERR, "Device CRC matches with file CRC. Skipping the update\n");
+       CrcMatched = true;
        return false;
     }
     else
     {
         sd_journal_print(LOG_INFO, "CRC not matched with the previous image. Continuing the update\n");
+        CrcMatched = false;
         return true;
     }
 }

--- a/src/vr_update_renesas_patch.cpp
+++ b/src/vr_update_renesas_patch.cpp
@@ -25,6 +25,7 @@ vr_update_renesas_patch::vr_update_renesas_patch(std::string Processor,
 
 bool vr_update_renesas_patch::crcCheckSum()
 {
+    CrcMatched = false;
     return true;
 }
 

--- a/src/vr_update_xdpe_patch.cpp
+++ b/src/vr_update_xdpe_patch.cpp
@@ -18,6 +18,7 @@ vr_update_xdpe_patch::vr_update_xdpe_patch(std::string Processor,
 
 bool vr_update_xdpe_patch::crcCheckSum()
 {
+    CrcMatched = false;
     return true;
 }
 


### PR DESCRIPTION
1. Slave address 0x60 is removed for chalupa platform. Also the VR names are updated for chalupa platforms. 

2. The webui Status message is updated with one of the following options. a) Update completed b) Update failed c) Update not required