### PR TITLE
Add TDA devices to the config json file

### DIFF
--- a/config/galena-vr.json
+++ b/config/galena-vr.json
@@ -24,6 +24,21 @@
          "SlaveAddress":"0x17",
          "Processor":"P0",
          "VrName":"VDD18_DUAL_VRM"
+      },
+      {
+         "SlaveAddress":"0x13",
+         "Processor":"None",
+         "VrName":"VDD_13_RUN"
+      },
+      {
+         "SlaveAddress":"0x14",
+         "Processor":"None",
+         "VrName":"VDD_33_DUAL"
+      },
+      {
+         "SlaveAddress":"0x15",
+         "Processor":"None",
+         "VrName":"VDD_5_DUAL"
       }
    ]
 }

--- a/config/huambo-vr.json
+++ b/config/huambo-vr.json
@@ -1,24 +1,19 @@
 {
    "VRConfigs":[
       {
-         "SlaveAddress":"0x60",
+         "SlaveAddress":"0x61",
          "Processor":"P0",
          "VrName":"P0_VDD_CORE0_RUN"
       },
       {
-         "SlaveAddress":"0x61",
+         "SlaveAddress":"0x62",
          "Processor":"P0",
          "VrName":"P0_VDD_CORE1_RUN"
       },
       {
-         "SlaveAddress":"0x62",
-         "Processor":"P0",
-         "VrName":"P0_VDD_IO_RUN"
-      },
-      {
          "SlaveAddress":"0x63",
          "Processor":"P0",
-         "VrName":"P0_VDD_11_SUS"
+         "VrName":"P0_VDD_VDDIO_RUN"
       },
       {
          "SlaveAddress":"0x64",
@@ -31,24 +26,19 @@
          "VrName":"P0_VDD_33_DUAL"
       },
       {
-         "SlaveAddress":"0x60",
+         "SlaveAddress":"0x61",
          "Processor":"P1",
          "VrName":"P1_VDD_CORE0_RUN"
       },
       {
-         "SlaveAddress":"0x61",
+         "SlaveAddress":"0x62",
          "Processor":"P1",
          "VrName":"P1_VDD_CORE1_RUN"
       },
       {
-         "SlaveAddress":"0x62",
-         "Processor":"P1",
-         "VrName":"P1_VDD_IO_RUN"
-      },
-      {
          "SlaveAddress":"0x63",
          "Processor":"P1",
-         "VrName":"P1_VDD_11_SUS"
+         "VrName":"P1_VDDIO_RUN"
       },
       {
          "SlaveAddress":"0x64",
@@ -59,6 +49,21 @@
          "SlaveAddress":"0x65",
          "Processor":"P1",
          "VrName":"P1_VDD_33_DUAL"
+      },
+      {
+         "SlaveAddress":"0x13",
+         "Processor":"None",
+         "VrName":"VDD_13_RUN"
+      },
+      {
+         "SlaveAddress":"0x14",
+         "Processor":"None",
+         "VrName":"VDD_33_DUAL"
+      },
+      {
+         "SlaveAddress":"0x15",
+         "Processor":"None",
+         "VrName":"VDD_5_DUAL"
       }
    ]
 }

--- a/config/recluse-vr.json
+++ b/config/recluse-vr.json
@@ -24,6 +24,21 @@
          "SlaveAddress":"0x17",
          "Processor":"P0",
          "VrName":"VDD18_DUAL_VRM"
+      },
+      {
+         "SlaveAddress":"0x13",
+         "Processor":"None",
+         "VrName":"VDD_13_RUN"
+      },
+      {
+         "SlaveAddress":"0x14",
+         "Processor":"None",
+         "VrName":"VDD_33_DUAL"
+      },
+      {
+         "SlaveAddress":"0x15",
+         "Processor":"None",
+         "VrName":"VDD_5_DUAL"
       }
    ]
 }

--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -107,6 +107,7 @@ extern "C"
 #define ISL_DRIVER_PATH       ("/sys/bus/i2c/drivers/isl68137/")
 #define MPS_DRIVER_PATH       ("/sys/bus/i2c/drivers/mp2975/")
 #define XDPE_DRIVER_PATH      ("/sys/bus/i2c/drivers/xdpe12284/")
+#define PMBUS_DRIVER_PATH     ("/sys/bus/i2c/drivers/pmbus/")
 
 #define SLEEP_1               (1000000)
 #define SLEEP_2               (2000000)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -489,7 +489,6 @@ int main(int argc, char* argv[])
                             {
                                 if(CrcMatched == true)
                                 {
-                                    sd_journal_print(LOG_INFO,"Updating Status to UptoDate\n");
                                     bundleInterfaceObj.Status[i] = "Already UpToDate";
                                 } else {
                                     bundleInterfaceObj.Status[i] = "Update Failed";

--- a/src/vr_update_infineon_tda.cpp
+++ b/src/vr_update_infineon_tda.cpp
@@ -13,7 +13,7 @@ vr_update_infineon_tda::vr_update_infineon_tda(std::string Processor,
           vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath)
 {
 
-    DriverPath = XDPE_DRIVER_PATH;
+    DriverPath = PMBUS_DRIVER_PATH;
 }
 
 bool vr_update_infineon_tda::crcCheckSum()


### PR DESCRIPTION
1. Added TDA devices to the config files of Huambo, Galena and Recluse
2. Removed Slave 0x60 for Huambo platform and renamed the VR's
3. TDA bus numbers are derived from PMBUS driver