### PR TITLE
Check silicon revision before updating VR

### DIFF
--- a/config/chalupa-vr.json
+++ b/config/chalupa-vr.json
@@ -52,16 +52,19 @@
       },
       {
          "SlaveAddress":"0x13",
+         "PmbusAddress":"0x43",
          "Processor":"None",
          "VrName":"VDD_13_RUN"
       },
       {
          "SlaveAddress":"0x14",
+         "PmbusAddress":"0x44",
          "Processor":"None",
          "VrName":"VDD_33_DUAL"
       },
       {
          "SlaveAddress":"0x15",
+         "PmbusAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_5_DUAL"
       }

--- a/config/galena-vr.json
+++ b/config/galena-vr.json
@@ -17,26 +17,31 @@
       },
       {
          "SlaveAddress":"0x16",
+         "PmbusAddress":"0x46",
          "Processor":"P0",
          "VrName":"VDD33_DUAL_VRM"
       },
       {
          "SlaveAddress":"0x17",
+         "PmbusAddress":"0x47",
          "Processor":"P0",
          "VrName":"VDD18_DUAL_VRM"
       },
       {
          "SlaveAddress":"0x13",
+         "PmbusAddress":"0x43",
          "Processor":"None",
          "VrName":"VDD_13_RUN"
       },
       {
          "SlaveAddress":"0x14",
+         "PmbusAddress":"0x44",
          "Processor":"None",
          "VrName":"VDD_33_DUAL"
       },
       {
          "SlaveAddress":"0x15",
+         "PmbusAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_5_DUAL"
       }

--- a/config/huambo-vr.json
+++ b/config/huambo-vr.json
@@ -52,16 +52,19 @@
       },
       {
          "SlaveAddress":"0x13",
+         "PmbusAddress":"0x43",
          "Processor":"None",
          "VrName":"VDD_13_RUN"
       },
       {
          "SlaveAddress":"0x14",
+         "PmbusAddress":"0x44",
          "Processor":"None",
          "VrName":"VDD_33_DUAL"
       },
       {
          "SlaveAddress":"0x15",
+         "PmbusAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_5_DUAL"
       }

--- a/config/recluse-vr.json
+++ b/config/recluse-vr.json
@@ -17,26 +17,31 @@
       },
       {
          "SlaveAddress":"0x16",
+         "PmbusAddress":"0x46",
          "Processor":"P0",
          "VrName":"VDD33_DUAL_VRM"
       },
       {
          "SlaveAddress":"0x17",
+         "PmbusAddress":"0x47",
          "Processor":"P0",
          "VrName":"VDD18_DUAL_VRM"
       },
       {
          "SlaveAddress":"0x13",
+         "PmbusAddress":"0x43",
          "Processor":"None",
          "VrName":"VDD_13_RUN"
       },
       {
          "SlaveAddress":"0x14",
+         "PmbusAddress":"0x44",
          "Processor":"None",
          "VrName":"VDD_33_DUAL"
       },
       {
          "SlaveAddress":"0x15",
+         "PmbusAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_5_DUAL"
       }

--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -116,6 +116,7 @@ class vr_update {
 
 protected:
     uint16_t SlaveAddress;
+    uint16_t PmbusAddress;
     uint16_t BusNumber;
     uint32_t Crc;
     std::string Processor;
@@ -128,11 +129,11 @@ protected:
 
 public:
  vr_update(std::string Processor,uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress);
 
  static vr_update* CreateVRFrameworkObject(std::string Model,
               uint16_t SlaveAddress, uint32_t Crc, std::string Processor,
-              std::string configFilePath,std::string UpdateType,std::string Revision);
+              std::string configFilePath,std::string UpdateType,std::string Revision,uint16_t PmbusAddress);
 
     virtual bool isUpdatable() = 0;
     virtual bool findBusNumber();

--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -108,7 +108,6 @@ extern "C"
 #define MPS_DRIVER_PATH       ("/sys/bus/i2c/drivers/mp2975/")
 #define XDPE_DRIVER_PATH      ("/sys/bus/i2c/drivers/xdpe12284/")
 #define PMBUS_DRIVER_PATH     ("/sys/bus/i2c/drivers/pmbus/")
-
 #define SLEEP_1               (1000000)
 #define SLEEP_2               (2000000)
 #define SLEEP_1000            (1000)
@@ -123,16 +122,17 @@ protected:
     std::string Model;
     std::string ConfigFilePath;
     std::string DriverPath;
+    std::string Revision;
     int fd;
     char updateFilePath[FILE_PATH_SIZE];
 
 public:
  vr_update(std::string Processor,uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
  static vr_update* CreateVRFrameworkObject(std::string Model,
               uint16_t SlaveAddress, uint32_t Crc, std::string Processor,
-              std::string configFilePath,std::string UpdateType);
+              std::string configFilePath,std::string UpdateType,std::string Revision);
 
     virtual bool isUpdatable() = 0;
     virtual bool findBusNumber();

--- a/inc/vr_update_infineon_tda.hpp
+++ b/inc/vr_update_infineon_tda.hpp
@@ -39,9 +39,9 @@ protected:
     int NextImgPtr;
 
 public:
-    vr_update_infineon_tda(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+    vr_update_infineon_tda(std::string Processor,uint32_t Crc,std::string Model,
+          uint16_t SlaveAddress,std::string ConfigFilePath,
+          std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_infineon_tda.hpp
+++ b/inc/vr_update_infineon_tda.hpp
@@ -2,6 +2,7 @@
 #define VR_UPDATE_TDA_H_
 
 #define PAGE_NUM_REG 0xFF
+#define SILICON_VER_REG 0xFD
 #define USER_IMG_PTR1 0xB4
 #define USER_IMG_PTR2 0xB6
 #define USER_IMG_PTR3 0xB8
@@ -20,6 +21,17 @@
 #define CRC_REG_1 0xAE
 #define CRC_REG_2 0xB0
 
+#define R2_REV1 0x8402
+#define R2_REV2 0x9202
+#define R4_REV1 0x8404
+#define R4_REV2 0x9204
+#define R5_REV1 0x8405
+#define R5_REV2 0x9205
+
+#define R2_REV ("R2")
+#define R4_REV ("R4")
+#define R5_REV ("R5")
+
 class vr_update_infineon_tda: public vr_update
 {
 
@@ -29,7 +41,7 @@ protected:
 public:
     vr_update_infineon_tda(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_infineon_xdpe.hpp
+++ b/inc/vr_update_infineon_xdpe.hpp
@@ -25,6 +25,7 @@
 /* CMD PREFIX */
 
 #define DEVICE_ID_CMD     (0xad)
+#define DEVICE_REV_CMD    (0xae)
 #define RPTR              (0xce)
 #define MFR_REG_WRITE     (0xde)
 #define MFR_REG_READ      (0xdf)
@@ -62,6 +63,11 @@
 
 #define USER_PROG_STATUS  (0x80)
 
+#define REV_A             ("RevA")
+#define REV_B             ("RevB")
+#define REVISION_2        (0x0101)
+#define REVISION_1        (0x0303)
+
 class vr_update_infineon_xdpe: public vr_update
 {
 
@@ -69,7 +75,7 @@ class vr_update_infineon_xdpe: public vr_update
 public:
     vr_update_infineon_xdpe(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_infineon_xdpe.hpp
+++ b/inc/vr_update_infineon_xdpe.hpp
@@ -73,9 +73,9 @@ class vr_update_infineon_xdpe: public vr_update
 
 
 public:
-    vr_update_infineon_xdpe(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+    vr_update_infineon_xdpe(std::string Processor,uint32_t Crc,
+          std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,
+          std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_mps.hpp
+++ b/inc/vr_update_mps.hpp
@@ -36,9 +36,9 @@ class vr_update_mps: public vr_update
 {
 
 public:
-    vr_update_mps(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+    vr_update_mps(std::string Processor,uint32_t Crc,std::string Model,
+          uint16_t SlaveAddress,std::string ConfigFilePath,
+          std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_mps.hpp
+++ b/inc/vr_update_mps.hpp
@@ -38,7 +38,7 @@ class vr_update_mps: public vr_update
 public:
     vr_update_mps(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_renesas_gen2.hpp
+++ b/inc/vr_update_renesas_gen2.hpp
@@ -30,7 +30,7 @@ class vr_update_renesas_gen2: public vr_update
 public:
     vr_update_renesas_gen2(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_renesas_gen2.hpp
+++ b/inc/vr_update_renesas_gen2.hpp
@@ -28,9 +28,9 @@ class vr_update_renesas_gen2: public vr_update
 {
 
 public:
-    vr_update_renesas_gen2(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+    vr_update_renesas_gen2(std::string Processor,uint32_t Crc,std::string Model,
+          uint16_t SlaveAddress,std::string ConfigFilePath,
+          std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_renesas_gen3.hpp
+++ b/inc/vr_update_renesas_gen3.hpp
@@ -29,7 +29,7 @@ class vr_update_renesas_gen3: public vr_update
 public:
     vr_update_renesas_gen3(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_renesas_gen3.hpp
+++ b/inc/vr_update_renesas_gen3.hpp
@@ -27,9 +27,9 @@ class vr_update_renesas_gen3: public vr_update
 {
 
 public:
-    vr_update_renesas_gen3(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+    vr_update_renesas_gen3(std::string Processor,uint32_t Crc,std::string Model,
+          uint16_t SlaveAddress,std::string ConfigFilePath,
+          std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_renesas_patch.hpp
+++ b/inc/vr_update_renesas_patch.hpp
@@ -38,8 +38,8 @@ class vr_update_renesas_patch: public vr_update
 
 public:
     vr_update_renesas_patch(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+          uint32_t Crc,std::string Model,uint16_t SlaveAddress,
+          std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_renesas_patch.hpp
+++ b/inc/vr_update_renesas_patch.hpp
@@ -39,7 +39,7 @@ class vr_update_renesas_patch: public vr_update
 public:
     vr_update_renesas_patch(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_xdpe_patch.hpp
+++ b/inc/vr_update_xdpe_patch.hpp
@@ -41,8 +41,8 @@ protected:
     uint16_t PatchFileSize;
 public:
     vr_update_xdpe_patch(std::string Processor,
-          uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
+          uint32_t Crc,std::string Model,uint16_t SlaveAddress,
+          std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/inc/vr_update_xdpe_patch.hpp
+++ b/inc/vr_update_xdpe_patch.hpp
@@ -42,7 +42,7 @@ protected:
 public:
     vr_update_xdpe_patch(std::string Processor,
           uint32_t Crc,std::string Model,
-          uint16_t SlaveAddress,std::string ConfigFilePath);
+          uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision);
 
     virtual bool crcCheckSum();
     virtual bool isUpdatable();

--- a/src/vr_update_infineon_tda.cpp
+++ b/src/vr_update_infineon_tda.cpp
@@ -8,9 +8,9 @@
 #include "vr_update.hpp"
 #include "vr_update_infineon_tda.hpp"
 
-vr_update_infineon_tda::vr_update_infineon_tda(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_infineon_tda::vr_update_infineon_tda(std::string Processor,uint32_t Crc,
+          std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
 
     DriverPath = PMBUS_DRIVER_PATH;

--- a/src/vr_update_infineon_xdpe.cpp
+++ b/src/vr_update_infineon_xdpe.cpp
@@ -11,9 +11,9 @@
 int partial_pmbus_section_count_number = 0;
 uint16_t partial_crc = 0;
 
-vr_update_infineon_xdpe::vr_update_infineon_xdpe(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_infineon_xdpe::vr_update_infineon_xdpe(std::string Processor,uint32_t Crc,
+          std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
 
     DriverPath = XDPE_DRIVER_PATH;

--- a/src/vr_update_mps.cpp
+++ b/src/vr_update_mps.cpp
@@ -7,9 +7,9 @@
 #include "vr_update.hpp"
 #include "vr_update_mps.hpp"
 
-vr_update_mps::vr_update_mps(std::string Processor,
-        uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-        vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_mps::vr_update_mps(std::string Processor,uint32_t Crc,
+        std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+        vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
         DriverPath = MPS_DRIVER_PATH;
 

--- a/src/vr_update_renesas_gen2.cpp
+++ b/src/vr_update_renesas_gen2.cpp
@@ -8,9 +8,9 @@
 #include "vr_update.hpp"
 #include "vr_update_renesas_gen2.hpp"
 
-vr_update_renesas_gen2::vr_update_renesas_gen2(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_renesas_gen2::vr_update_renesas_gen2(std::string Processor,uint32_t Crc,
+          std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
 
     DriverPath = ISL_DRIVER_PATH;

--- a/src/vr_update_renesas_gen2.cpp
+++ b/src/vr_update_renesas_gen2.cpp
@@ -9,8 +9,8 @@
 #include "vr_update_renesas_gen2.hpp"
 
 vr_update_renesas_gen2::vr_update_renesas_gen2(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath)
+          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
 {
 
     DriverPath = ISL_DRIVER_PATH;

--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -8,9 +8,9 @@
 #include "vr_update.hpp"
 #include "vr_update_renesas_gen3.hpp"
 
-vr_update_renesas_gen3::vr_update_renesas_gen3(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_renesas_gen3::vr_update_renesas_gen3(std::string Processor,uint32_t Crc,
+          std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
 
     DriverPath = ISL_DRIVER_PATH;

--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -9,8 +9,8 @@
 #include "vr_update_renesas_gen3.hpp"
 
 vr_update_renesas_gen3::vr_update_renesas_gen3(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath)
+          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
 {
 
     DriverPath = ISL_DRIVER_PATH;
@@ -444,12 +444,12 @@ bool vr_update_renesas_gen3::ValidateFirmware()
         {
             if(StatusData[BankStatus] == STATUS_BIT_8)
             {
-                sd_journal_print(LOG_INFO, "CRC mismatch OTP for bank = %d\n",BankNumber);
+                sd_journal_print(LOG_ERR, "CRC mismatch OTP for bank = %d\n",BankNumber);
                 return false;
             }
             else if(StatusData[BankStatus] == STATUS_BIT_4)
             {
-                sd_journal_print(LOG_INFO, "CRC mismatch RAM for bank = %d\n", BankNumber);
+                sd_journal_print(LOG_ERR, "CRC mismatch RAM for bank = %d\n", BankNumber);
                 return false;
             }
             else if(StatusData[BankStatus] == STATUS_BIT_2)

--- a/src/vr_update_renesas_patch.cpp
+++ b/src/vr_update_renesas_patch.cpp
@@ -15,9 +15,9 @@ struct PMBusPayload
    u_int32_t data;
 };
 
-vr_update_renesas_patch::vr_update_renesas_patch(std::string Processor,
-          uint32_t Crc,std::string Model, uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_renesas_patch::vr_update_renesas_patch(std::string Processor,uint32_t Crc,
+         std::string Model, uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
 
     DriverPath = ISL_DRIVER_PATH;

--- a/src/vr_update_renesas_patch.cpp
+++ b/src/vr_update_renesas_patch.cpp
@@ -16,8 +16,8 @@ struct PMBusPayload
 };
 
 vr_update_renesas_patch::vr_update_renesas_patch(std::string Processor,
-          uint32_t Crc,std::string Model, uint16_t SlaveAddress,std::string ConfigFilePath):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath)
+          uint32_t Crc,std::string Model, uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
 {
 
     DriverPath = ISL_DRIVER_PATH;

--- a/src/vr_update_xdpe_patch.cpp
+++ b/src/vr_update_xdpe_patch.cpp
@@ -8,9 +8,9 @@
 #include "vr_update.hpp"
 #include "vr_update_xdpe_patch.hpp"
 
-vr_update_xdpe_patch::vr_update_xdpe_patch(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
+vr_update_xdpe_patch::vr_update_xdpe_patch(std::string Processor,uint32_t Crc,
+          std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision,uint16_t PmbusAddress):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision,PmbusAddress)
 {
 
     DriverPath = XDPE_DRIVER_PATH;

--- a/src/vr_update_xdpe_patch.cpp
+++ b/src/vr_update_xdpe_patch.cpp
@@ -9,8 +9,8 @@
 #include "vr_update_xdpe_patch.hpp"
 
 vr_update_xdpe_patch::vr_update_xdpe_patch(std::string Processor,
-          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath):
-          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath)
+          uint32_t Crc,std::string Model,uint16_t SlaveAddress,std::string ConfigFilePath,std::string Revision):
+          vr_update(Processor,Crc,Model,SlaveAddress,ConfigFilePath,Revision)
 {
 
     DriverPath = XDPE_DRIVER_PATH;


### PR DESCRIPTION
For XDPE and TDA parts , read the silicon revision from the VR device and check if the config file is compatible for update.