### PR TITLE
Fix i2c_smbus_read_i2c_block_data return value check

### DIFF
--- a/src/vr_update_mps.cpp
+++ b/src/vr_update_mps.cpp
@@ -29,7 +29,7 @@ bool vr_update_mps::crcCheckSum(){
      }
 
     ret = i2c_smbus_read_i2c_block_data(fd, CRC_ADDR, BYTE_COUNT_4, rdata);
-    if (rdata < SUCCESS)
+    if (ret < SUCCESS)
     {
            sd_journal_print(LOG_ERR, "Error: Reading CRC from device failed\n");
            return false;
@@ -80,7 +80,7 @@ bool vr_update_mps::isUpdatable(){
 
     ret = i2c_smbus_read_i2c_block_data(fd, DEVICE_ID_REG, BYTE_COUNT_2, rdata); 
 
-    if(rdata >= SUCCESS)
+    if(ret >= SUCCESS)
     {
         VrDeviceId = (rdata[INDEX_0] << SHIFT_8) | rdata[INDEX_1];
     }
@@ -92,7 +92,7 @@ bool vr_update_mps::isUpdatable(){
 
     ret = i2c_smbus_read_i2c_block_data(fd, CONFIG_ID_REG, BYTE_COUNT_3, rdata);
 
-    if(rdata >= SUCCESS)
+    if(ret >= SUCCESS)
     {
         VrConfigId = (rdata[INDEX_0] << SHIFT_16) | (rdata[INDEX_1] << SHIFT_8) | rdata[INDEX_2];
     }

--- a/src/vr_update_mps285x.cpp
+++ b/src/vr_update_mps285x.cpp
@@ -53,7 +53,7 @@ bool vr_update_mps285x::isUpdatable()
     /*Device ID ID from 9Ah@page0*/
     ret = i2c_smbus_read_i2c_block_data(fd, DEVICE_ID_REG, BYTE_COUNT_4, rdata);
 
-    if(rdata >= SUCCESS)
+    if(ret >= SUCCESS)
     {
         VrDeviceId = ((uint16_t)rdata[INDEX_2] << SHIFT_8) | rdata[INDEX_1];
     }
@@ -66,7 +66,7 @@ bool vr_update_mps285x::isUpdatable()
     /*Config ID from 9Dh@page0*/
     ret = i2c_smbus_read_i2c_block_data(fd, CONFIG_ID_REG, BYTE_COUNT_4, rdata);
 
-    if(rdata >= SUCCESS)
+    if(ret >= SUCCESS)
     {
         VrConfigId = ((uint16_t)rdata[INDEX_2] << SHIFT_8) | rdata[INDEX_1];
     }


### PR DESCRIPTION
Fixes the error when trying to build on the latest OpenBMC:
```
| …/src/vr_update_mps.cpp: In member function 'virtual bool vr_update_mps::crcCheckSum()':
| …/src/vr_update_mps.cpp:32:15: error: ordered comparison of pointer with integer zero ('uint8_t*' {aka 'unsigned char*'} and 'int')
|    32 |     if (rdata < SUCCESS)
| …/src/vr_update_mps.cpp: In member function 'virtual bool vr_update_mps::isUpdatable()':
| …/src/vr_update_mps.cpp:83:14: error: ordered comparison of pointer with integer zero ('uint8_t*' {aka 'unsigned char*'} and 'int')
|    83 |     if(rdata >= SUCCESS)
| …/src/vr_update_mps.cpp:95:14: error: ordered comparison of pointer with integer zero ('uint8_t*' {aka 'unsigned char*'} and 'int')
|    95 |     if(rdata >= SUCCESS)
```
