### PR TITLE
Add VDD_5_DUAL VR to Congo config file

### DIFF
--- a/config/congo-vr.json
+++ b/config/congo-vr.json
@@ -34,6 +34,11 @@
          "SlaveAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_33_RUN"
+      },
+      {
+         "SlaveAddress":"0x48",
+         "Processor":"None",
+         "VrName":"VDD_5_DUAL"
       }
    ]
 }


### PR DESCRIPTION
Added VR VDD_5_DUAL connected to slave 0x48
to the Congo config json file.