### PR TITLE
Update Gen3 Renesas programming procedure

### DIFF
--- a/config/congo-vr.json
+++ b/config/congo-vr.json
@@ -16,27 +16,32 @@
          "VrName":"P0_VDD_VDDIO_RUN"
       },
       {
-         "SlaveAddress":"0x46",
+         "SlaveAddress":"0x16",
+         "PmbusAddress":"0x46",
          "Processor":"P0",
          "VrName":"P0_VDD_18_S5_RUN"
       },
       {
-         "SlaveAddress":"0x47",
+         "SlaveAddress":"0x17",
+         "PmbusAddress":"0x47",
          "Processor":"P0",
          "VrName":"P0_VDD_33_S5_RUN"
       },
       {
-         "SlaveAddress":"0x43",
+         "SlaveAddress":"0x13",
+         "PmbusAddress":"0x43",
          "Processor":"None",
          "VrName":"VDD_33_DUAL"
       },
       {
-         "SlaveAddress":"0x45",
+         "SlaveAddress":"0x15",
+         "PmbusAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_33_RUN"
       },
       {
-         "SlaveAddress":"0x48",
+         "SlaveAddress":"0x18",
+         "PmbusAddress":"0x48",
          "Processor":"None",
          "VrName":"VDD_5_DUAL"
       }

--- a/config/morocco-vr.json
+++ b/config/morocco-vr.json
@@ -16,12 +16,14 @@
          "VrName":"P0_VDD_VDDIO_RUN"
       },
       {
-         "SlaveAddress":"0x46",
+         "SlaveAddress":"0x16",
+         "PmbusAddress":"0x46",
          "Processor":"P0",
          "VrName":"P0_VDD_18_S5_RUN"
       },
       {
-         "SlaveAddress":"0x47",
+         "SlaveAddress":"0x17",
+         "PmbusAddress":"0x47",
          "Processor":"P0",
          "VrName":"P0_VDD_33_S5_RUN"
       },
@@ -41,32 +43,38 @@
          "VrName":"P1_VDD_VDDIO_RUN"
       },
       {
-         "SlaveAddress":"0x46",
+         "SlaveAddress":"0x16",
+         "PmbusAddress":"0x46",
          "Processor":"P1",
          "VrName":"P1_VDD_18_S5_RUN"
       },
       {
-         "SlaveAddress":"0x47",
+         "SlaveAddress":"0x17",
+         "PmbusAddress":"0x47",
          "Processor":"P1",
          "VrName":"P1_VDD_33_S5_RUN"
       },
       {
-         "SlaveAddress":"0x43",
+         "SlaveAddress":"0x13",
+         "PmbusAddress":"0x43",
          "Processor":"None",
          "VrName":"VDD_33_DUAL"
       },
       {
-         "SlaveAddress":"0x44",
+         "SlaveAddress":"0x14",
+         "PmbusAddress":"0x44",
          "Processor":"None",
          "VrName":"VDD_33_RUN_B"
       },
       {
-         "SlaveAddress":"0x45",
+         "SlaveAddress":"0x15",
+         "PmbusAddress":"0x45",
          "Processor":"None",
          "VrName":"VDD_33_RUN"
       },
       {
-         "SlaveAddress":"0x48",
+         "SlaveAddress":"0x18",
+         "PmbusAddress":"0x48",
          "Processor":"None",
          "VrName":"VDD_5_DUAL"
       }

--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -49,6 +49,8 @@ extern "C"
 #define RAA229620             ("RAA229620")
 #define RAA229621             ("RAA229621")
 #define ISL68220              ("ISL68220")
+#define RAA229639             ("RAA229639")
+#define RAA22964              ("RAA22964")
 #define RENESAS               ("RENESAS")
 #define INFINEON_XDPE         ("XDPE")
 #define INFINEON_TDA          ("TDA")

--- a/inc/vr_update_infineon_tda.hpp
+++ b/inc/vr_update_infineon_tda.hpp
@@ -8,7 +8,6 @@
 #define USER_IMG_PTR3 0xB8
 #define USER_READ_CMD 0x41
 #define USER_READ_CMD 0x41
-#define USER_PROG_CMD 0x00D6
 #define UNLOCK_REG 0xD4
 #define USER_PROG_CMD 0x00D6
 #define PROG_STATUS_REG 0xD7
@@ -16,13 +15,16 @@
 #define USER_PROG_STATUS 0x80
 #define CRC_REG_1 0xAE
 #define CRC_REG_2 0xB0
+#define INDEX_80 0x80
+#define INDEX_300 0x300
+#define INDEX_380 0x380
+#define INDEX_390 0x390
 
 #define R2_REV1 0x8402
 #define R2_REV2 0x9202
 #define R4_REV1 0x8404
 #define R4_REV2 0x9204
-#define R5_REV1 0x8405
-#define R5_REV2 0x9205
+#define R5_REVISION 0x05
 
 #define R2_REV ("R2")
 #define R4_REV ("R4")

--- a/inc/vr_update_renesas_gen3.hpp
+++ b/inc/vr_update_renesas_gen3.hpp
@@ -1,7 +1,7 @@
 #ifndef VR_UPDATE_RENESAS_GEN3_H_
 #define VR_UPDATE_RENESAS_GEN3_H_
 
-#define DISABLE_PACKET       (0x00A2)
+#define DISABLE_PACKET       (0x0102)
 #define FINISH_CAPTURE       (0x0002)
 #define DEVICE_FW_VERSION    (0x0030)
 #define HALT_FW              (0x0002)
@@ -10,12 +10,12 @@
 #define FW_WRITE             (0xE6)
 #define DMA_WRITE             0xC7
 #define DMA_READ             (0xC5)
-#define GEN3_CRC_ADDR        0x0094
+#define GEN3_CRC_ADDR        (0x00F8)
 #define GEN3_NVM_SLOT_ADDR   (0x0035)
 #define DEV_ID_CMD           (0xAD)
 #define DEV_REV_REV          (0xAE)
-#define GEN3_BANK_REG        (0x007F)
-#define GEN3_PRGM_STATUS     (0x007E)
+#define GEN3_BANK_REG        (0x0084)
+#define GEN3_PRGM_STATUS     (0x0083)
 #define DEVICE_REVISION      (0x6000000)
 
 #define MAXIMUM_SIZE         (255)

--- a/src/vr_update.cpp
+++ b/src/vr_update.cpp
@@ -64,7 +64,9 @@ vr_update* vr_update::CreateVRFrameworkObject(std::string Model,
 	else if ((strcasecmp(Model.c_str(), RAA229613) == SUCCESS) ||
             (strcasecmp(Model.c_str(), RAA229625) == SUCCESS) ||
             (strcasecmp(Model.c_str(), RAA229620) == SUCCESS) ||
-            (strcasecmp(Model.c_str(), RAA229621) == SUCCESS)) {
+            (strcasecmp(Model.c_str(), RAA229621) == SUCCESS) ||
+            (strcasecmp(Model.c_str(), RAA229639) == SUCCESS) ||
+            (strcasecmp(Model.c_str(), RAA22964) == SUCCESS)) {
 		p = new vr_update_renesas_gen3(Processor,Crc,Model,SlaveAddress,configFilePath,Revision,PmbusAddress);
 	}
 

--- a/src/vr_update_infineon_tda.cpp
+++ b/src/vr_update_infineon_tda.cpp
@@ -33,8 +33,7 @@ bool vr_update_infineon_tda::crcCheckSum()
         return false;
     }
 
-    /* Read register 0x0B4 [15:0] + 0x0B6 [15:0] + 0x0B8 [15:0]
-       to determine next USER image pointer*/
+    /* Read register 0x0B8 [15:0] to determine next USER image pointer*/
 
     rdata = i2c_smbus_read_word_data(fd,USER_IMG_PTR3);
     if (rdata < 0)
@@ -45,27 +44,9 @@ bool vr_update_infineon_tda::crcCheckSum()
 
     UserImgPtr = UserImgPtr | rdata;
 
-    rdata = i2c_smbus_read_word_data(fd,USER_IMG_PTR2);
+    sd_journal_print(LOG_INFO, "UserImgPtr: 0x%lx\n", UserImgPtr);
 
-    if (rdata < SUCCESS)
-    {
-        sd_journal_print(LOG_ERR, "Error: Failed to read data\n");
-        return false;
-    }
-
-    UserImgPtr = UserImgPtr | ((uint64_t )rdata << BASE_16) ;
-
-    rdata = i2c_smbus_read_word_data(fd,USER_IMG_PTR1);
-
-    if (rdata < SUCCESS)
-    {
-        sd_journal_print(LOG_ERR, "Error: Failed to read data\n");
-        return false;
-    }
-
-    UserImgPtr = UserImgPtr | ((uint64_t )rdata << INDEX_32) ;
-
-    for(i = INDEX_0 ; i < INDEX_48 ; i++)
+    for(i = INDEX_0 ; i < 15 ; i++)
     {
         if( (UserImgPtr & ( mask << i)) == SUCCESS)
         {
@@ -74,6 +55,7 @@ bool vr_update_infineon_tda::crcCheckSum()
     }
     NextImgPtr = i;
 
+     sd_journal_print(LOG_INFO,"Nextimageptr: %d\n", NextImgPtr);
     /*Check Previous Image CRC*/
 
     /*Send user section command*/
@@ -81,6 +63,7 @@ bool vr_update_infineon_tda::crcCheckSum()
     int UserSectionCmd = USER_READ_CMD;
 
     UserSectionCmd = ( CrcImgPtr << INDEX_8) | UserSectionCmd;
+    sd_journal_print(LOG_INFO, "User command to write to 0xD6 = 0x%x\n ",UserSectionCmd);
 
     rc = i2c_smbus_write_word_data(fd, USER_PROG_CMD , UserSectionCmd);
 
@@ -148,17 +131,16 @@ bool vr_update_infineon_tda::crcCheckSum()
         CrcMatched = false;
     }
 
-
     return true;
 }
 
 bool vr_update_infineon_tda::isUpdatable()
 {
 
-    uint16_t rdata = 0;
+    uint8_t rdata = 0;
     int rc = FAILURE;
 
-    if(NextImgPtr > 40 )
+    if(NextImgPtr > 13 )
     {
         std::cout << "OTP for user section is not available\n";
         return false;
@@ -175,24 +157,14 @@ bool vr_update_infineon_tda::isUpdatable()
 
         /* Read register 0xFD to get the silicon version*/
 
-        rdata = i2c_smbus_read_word_data(fd,SILICON_VER_REG);
+        rdata = i2c_smbus_read_byte_data(fd,SILICON_VER_REG);
         if (rdata < 0)
         {
             sd_journal_print(LOG_ERR, "Error: Failed to read data\n");
             return false ;
         }
 
-        if((rdata == R2_REV1 || rdata == R2_REV2) &&
-            ((strcasecmp(Revision.c_str(), R2_REV)) == SUCCESS))
-        {
-            sd_journal_print(LOG_INFO, "R2 revision matched\n");
-        }
-        else if((rdata == R4_REV1 || rdata == R4_REV2) &&
-            ((strcasecmp(Revision.c_str(), R4_REV)) == SUCCESS))
-        {
-            sd_journal_print(LOG_INFO, "R4 revision matched\n");
-        }
-        else if((rdata == R5_REV1 || rdata == R5_REV2) &&
+        if((rdata == R5_REVISION) &&
             ((strcasecmp(Revision.c_str(), R5_REV)) == SUCCESS))
         {
             sd_journal_print(LOG_INFO, "R5 revision matched\n");
@@ -203,7 +175,6 @@ bool vr_update_infineon_tda::isUpdatable()
             sd_journal_print(LOG_ERR,"VR device silicion revision is not compatible for the update. Aborting the process...\n");
             return false;
         }
-
         return true;
     }
 }
@@ -279,9 +250,11 @@ bool vr_update_infineon_tda::UpdateFirmware()
                             index_range = std::stoi(word, nullptr, BASE_16);
                             if(index_range < INDEX_40)
                                 break;
-                            else if(index_range > INDEX_70 && index_range < INDEX_200)
+                            else if(index_range >= INDEX_80 && index_range < INDEX_200)
                                 break;
-                            else if(index_range > INDEX_2FF)
+                            else if(index_range >= INDEX_300 && index_range < INDEX_380)
+                                break;
+                            else if(index_range >= INDEX_390)
                                 break;
 
                             std::cout << word << std::endl;
@@ -328,7 +301,16 @@ bool vr_update_infineon_tda::UpdateFirmware()
         newfile.close();
     }
 
-    int UserSectionCmd = 0x42;
+    /* Change to page 0 by writing 0 to register 0xFF */
+    rc = i2c_smbus_write_byte_data(fd, PAGE_NUM_REG, INDEX_0);
+
+    if (rc != SUCCESS) {
+        sd_journal_print(LOG_ERR, "Error: Changing page number to 0 failed\n");
+        return false;
+    }
+
+    /*Write programming command 0x3F42 to register 0x00D6*/
+    int UserSectionCmd = 0x3F42;
 
     UserSectionCmd = ( NextImgPtr << INDEX_8) | UserSectionCmd;
 
@@ -341,7 +323,7 @@ bool vr_update_infineon_tda::UpdateFirmware()
     }
 
     /*Wait for 200ms */
-    usleep(200 * 1000);
+    sleep(1);
 
     return true;
 }

--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -162,7 +162,7 @@ bool vr_update_renesas_gen3::isUpdatable()
         VrDeviceId = (rdata[INDEX_4] << SHIFT_24) | (rdata[INDEX_3] << SHIFT_16) |
                     (rdata[INDEX_2] << SHIFT_8) | rdata[INDEX_1];
 
-        sd_journal_print(LOG_INFO, "Device ID from the VR = %d\n",VrDeviceId );
+        sd_journal_print(LOG_INFO, "Device ID from the VR = 0x%x\n",VrDeviceId );
     }
     else
     {
@@ -197,7 +197,8 @@ bool vr_update_renesas_gen3::isUpdatable()
 
     if(VrDeviceId == FileDeviceId)
     {
-        sd_journal_print(LOG_INFO, "VR device id and file devie id matched\n");
+        sd_journal_print(LOG_DEBUG, "VR device id and file devie id matched\n");
+        rc = true;
     }
     else
     {
@@ -205,59 +206,6 @@ bool vr_update_renesas_gen3::isUpdatable()
         rc = false;
         goto Clean;
 
-    }
-
-    /*Device revision verification*/
-
-    //Read IC_DEV_REVISION from the device
-    std::fill_n(rdata,MAXIMUM_SIZE,0);
-
-    ret = i2c_smbus_read_i2c_block_data(fd, DEV_REV_REV, BYTE_COUNT_5, rdata);
-
-    if (ret >= SUCCESS)
-    {
-        DeviceRevision = (rdata[INDEX_4] << SHIFT_24) | (rdata[INDEX_3] << SHIFT_16)
-                                      | (rdata[INDEX_2] << SHIFT_8) | rdata[INDEX_1];
-
-        sd_journal_print(LOG_INFO, "Device revision from VR device = 0x%x\n", DeviceRevision);
-    }
-    else
-    {
-        sd_journal_print(LOG_ERR, "Failed to read device revision from the VR device\n");
-        rc = false;
-        goto Clean;
-    }
-
-     /*Read device revison from config file*/
-    if(getline(cFile, line))
-    {
-        std::string Rev = line.substr(INDEX_8, INDEX_8);
-        FileRevision = std::stoull(Rev, nullptr, BASE_16);
-        sd_journal_print(LOG_INFO, "Device revision from config file = 0x%x\n", FileRevision);
-    }
-    else
-    {
-        sd_journal_print(LOG_ERR, "Failed to read device revision from config file\n");
-        rc = false;
-        goto Clean;
-    }
-
-    if(DeviceRevision < DEVICE_REVISION)
-    {
-        sd_journal_print(LOG_ERR, "The device revision number is lesser than 6.0.0.0.Contact Renesas for support\n");
-        rc = false;
-        goto Clean;
-    }
-
-    if(((FileRevision >> SHIFT_24 ) && INT_255) < ((DeviceRevision >> SHIFT_24) && INT_255))
-    {
-        sd_journal_print(LOG_ERR, "File Revision is less than device revision. Aborting the update\n");
-        rc = false;
-    }
-    else
-    {
-        sd_journal_print(LOG_ERR, "Device Revision and File Revision matched\n");
-        rc = true;
     }
 
 Clean:


### PR DESCRIPTION
Update the Renesas programming procedure as per the RENESAS GENERATION 3.5 PROGRAMMING GUIDE.

Update the Infineon TDA programming procedure as per the AN_2308_163442-V1.2(TDA38xxxRev5 Programming Guide)

Add PMBUS address and Slave address in the Congo and Morocco config file.

Test fields: Verified in Congo system 