### PR TITLE
Renesas VR changes

### DIFF
--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -126,6 +126,8 @@ extern "C"
 #define INDEX_200 (0x200)
 #define INDEX_2FF (0x2FF)
 
+#define PATCH_VERSION_FILE ("/var/lib/vr-config/renesas-patch.csv")
+
 class vr_update
 {
   protected:

--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -112,6 +112,7 @@ extern "C"
 #define LENGTH_0 (0)
 
 #define ISL_DRIVER_PATH ("/sys/bus/i2c/drivers/isl68137/")
+#define RAA_DRIVER_PATH ("/sys/bus/i2c/drivers/raa229126/")
 #define MPS_DRIVER_PATH ("/sys/bus/i2c/drivers/mp2975/")
 #define MPS2856_DRIVER_PATH ("/sys/bus/i2c/drivers/mp2856/")
 #define MPS2857_DRIVER_PATH ("/sys/bus/i2c/drivers/mp2857/")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -504,6 +504,18 @@ int main(int argc, char* argv[])
             }
         }
 
+        if (std::filesystem::exists(PATCH_VERSION_FILE))
+        {
+            std::filesystem::remove(PATCH_VERSION_FILE);
+        }
+
+        std::ofstream patchFile;
+        patchFile.open(PATCH_VERSION_FILE, std::ios::app);
+        patchFile
+            << "#SlaveAddress,BusNUmber,VersionBeforeUpdate,VersionAfterUpdate"
+            << std::endl;
+        patchFile.close();
+
         if (getBundleVersionInterface(bus) == false)
         {
             if (std::filesystem::exists(VR_PLATFORM_FILE))

--- a/src/vr_update.cpp
+++ b/src/vr_update.cpp
@@ -61,6 +61,7 @@ vr_update* vr_update::CreateVRFrameworkObject(
         {
             sd_journal_print(LOG_INFO,
                              "Renesas Gen3.5 patch update triggered\n");
+
             p = new vr_update_renesas_gen3p5_patch(
                 Processor, Crc, Model, SlaveAddress, configFilePath, Revision,
                 PmbusAddress,configFilePathArr);

--- a/src/vr_update_renesas_gen3.cpp
+++ b/src/vr_update_renesas_gen3.cpp
@@ -15,7 +15,7 @@ vr_update_renesas_gen3::vr_update_renesas_gen3(
     vr_update(Processor, Crc, Model, SlaveAddress, ConfigFilePath, Revision,
               PmbusAddress)
 {
-    DriverPath = ISL_DRIVER_PATH;
+    DriverPath = RAA_DRIVER_PATH;
 }
 
 bool vr_update_renesas_gen3::crcCheckSum()

--- a/src/vr_update_renesas_gen3p5_patch.cpp
+++ b/src/vr_update_renesas_gen3p5_patch.cpp
@@ -23,7 +23,7 @@ vr_update_renesas_gen3p5_patch::vr_update_renesas_gen3p5_patch(
               PmbusAddress),
     configFilePathArr(configFilePathArr)
 {
-    DriverPath = ISL_DRIVER_PATH;
+    DriverPath = RAA_DRIVER_PATH;
 }
 
 bool vr_update_renesas_gen3p5_patch::crcCheckSum()

--- a/src/vr_update_renesas_gen3p5_patch.cpp
+++ b/src/vr_update_renesas_gen3p5_patch.cpp
@@ -87,9 +87,13 @@ bool vr_update_renesas_gen3p5_patch::isUpdatable()
                        (rdata[INDEX_2] << SHIFT_16) |
                        (rdata[INDEX_1] << SHIFT_8) | rdata[INDEX_0];
 
+            std::ofstream patchFile;
+            patchFile.open(PATCH_VERSION_FILE, std::ios::app);
             sd_journal_print(LOG_INFO,
                              "Device firmware version before update = 0x%x\n",
                              DeviceFw);
+
+            patchFile << BusNumber << ",0x" << std::hex << SlaveAddress << ",0x" << std::hex << DeviceFw;
 
             if ((DeviceFw == PATCH_FW_1) || (DeviceFw == PATCH_FW_2))
             {
@@ -135,8 +139,11 @@ bool vr_update_renesas_gen3p5_patch::isUpdatable()
                 sd_journal_print(
                     LOG_ERR,
                     "The FW version is not supported for patch update\n");
+                patchFile << ",NotUpdated" << std::endl;
+                patchFile.close();
                 return false;
             }
+            patchFile.close();
         }
         else
         {
@@ -490,6 +497,11 @@ bool vr_update_renesas_gen3p5_patch::ValidateFirmware()
             sd_journal_print(LOG_INFO,
                              "Device firmware version after update = 0x%x\n",
                              DeviceFw);
+
+            std::ofstream patchFile;
+            patchFile.open(PATCH_VERSION_FILE, std::ios::app);
+            patchFile << ",0x" << std::hex << DeviceFw << std::endl;
+            patchFile.close();
         }
     }
     return true;


### PR DESCRIPTION
Changed the VR drivers as the latest parts are compatible with raa229126 driver.

Store the patch version before and after update of Renesas
VRs in a csv file which will be utilized by Nexus BKC
Installer implementation.

Verified : Tested in Congo and Kenya platform.
