### PR TITLE
Add support for Malawi VR update

### DIFF
--- a/config/vr-config-info
+++ b/config/vr-config-info
@@ -59,7 +59,7 @@ install_vr_platform_config()
        "80" | "81" | "86") #Congo board_ids
           cp /usr/sbin/congo-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "82" | "83" | "87") #Morocco board_ids
+       "82" | "83" | "87" | "8a") #Morocco board_ids
           cp /usr/sbin/morocco-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
        "84") #kenya board_ids

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,7 @@ constexpr auto bundleVersionInterface =
 #define MOROCCO 130   // 0x82
 #define MOROCCO_1 131 // 0x83
 #define MOROCCO_2 135 // 0x87
+#define MALAWI 138    // 0x8A
 
 #define KENYA 132     // 0x84
 
@@ -421,7 +422,7 @@ bool PlatformIDValidation(std::string BoardName)
             PlatformName = "Congo";
         }
         else if ((board_id == MOROCCO) || (board_id == MOROCCO_1) ||
-                 (board_id == MOROCCO_2))
+                 (board_id == MOROCCO_2) || (board_id == MALAWI))
         {
             PlatformName = "Morocco";
         }


### PR DESCRIPTION
Enabled VR update support for Malawi platforms
which has the same configuration as morocco platform.

Tested fields: Verified in Congo platform.