### PR TITLE
Display Renesas VR version in GUI

### DIFF
--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -165,6 +165,7 @@ class vr_update
     virtual bool crcCheckSum() = 0;
     virtual bool ValidateFirmware() = 0;
     bool CrcMatched;
+    uint32_t devVersion;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,9 +128,10 @@ struct bundleInterfaceStruct
 bundleInterfaceStruct bundleInterfaceObj;
 
 int vrUpdate(std::string Model, uint16_t SlaveAddress, uint32_t Crc,
-             std::string Processor, std::string configFilePath,
-             std::string UpdateType, bool* CrcMatched, std::string Revision,
-             uint16_t PmbusAddress, std::vector<std::string>& configFilePathArr)
+             uint32_t* Version, std::string Processor,
+             std::string configFilePath, std::string UpdateType,
+             bool* CrcMatched, std::string Revision, uint16_t PmbusAddress,
+             std::vector<std::string>& configFilePathArr)
 {
     int ret = FAILURE;
 
@@ -169,6 +170,8 @@ int vrUpdate(std::string Model, uint16_t SlaveAddress, uint32_t Crc,
         }
 
         rc = vr_update_obj->isUpdatable();
+        *Version = vr_update_obj->devVersion;
+
         if (rc != true)
         {
             ret = FAILURE;
@@ -176,6 +179,7 @@ int vrUpdate(std::string Model, uint16_t SlaveAddress, uint32_t Crc,
         }
 
         rc = vr_update_obj->UpdateFirmware();
+
         if (rc != true)
         {
             ret = FAILURE;
@@ -183,6 +187,8 @@ int vrUpdate(std::string Model, uint16_t SlaveAddress, uint32_t Crc,
         }
 
         rc = vr_update_obj->ValidateFirmware();
+        *Version = vr_update_obj->devVersion;
+
         if (rc != true)
         {
             ret = FAILURE;
@@ -466,6 +472,7 @@ int main(int argc, char* argv[])
     uint16_t PmbusAddress = 0;
     std::string BoardName;
     uint32_t Crc;
+    uint32_t deviceVersion = 0;
     std::string version;
     std::string UpdateType;
     std::string Revision;
@@ -714,9 +721,10 @@ int main(int argc, char* argv[])
                                  "Updating VR for the Slave Address = 0x%x",
                                  SlaveAddress);
 
-                ret = vrUpdate(Model, SlaveAddress, Crc, Processor,
-                               configFilePath, UpdateType, &CrcMatched,
-                               Revision, PmbusAddress, configFilePathArr);
+                ret = vrUpdate(Model, SlaveAddress, Crc, &deviceVersion,
+                               Processor, configFilePath, UpdateType,
+                               &CrcMatched, Revision, PmbusAddress,
+                               configFilePathArr);
 
                 for (int i = 0; i < bundleInterfaceObj.SlaveAddress.size(); i++)
                 {
@@ -726,7 +734,17 @@ int main(int argc, char* argv[])
                         if (strcasecmp(bundleInterfaceObj.Processor[i].c_str(),
                                        Processor.c_str()) == SUCCESS)
                         {
-                            bundleInterfaceObj.Versions[i] = version;
+                            if (deviceVersion != 0)
+                            {
+                                std::string hexVersion =
+                                    std::format("{:08X}", deviceVersion);
+                                bundleInterfaceObj.Versions[i] =
+                                    "0x" + hexVersion;
+                            }
+                            else
+                            {
+                                bundleInterfaceObj.Versions[i] = version;
+                            }
                             if (ret == SUCCESS)
                             {
                                 bundleInterfaceObj.Checksum[i] = CrcConfig;

--- a/src/vr_update_renesas_gen3p5_patch.cpp
+++ b/src/vr_update_renesas_gen3p5_patch.cpp
@@ -93,7 +93,10 @@ bool vr_update_renesas_gen3p5_patch::isUpdatable()
                              "Device firmware version before update = 0x%x\n",
                              DeviceFw);
 
-            patchFile << BusNumber << ",0x" << std::hex << SlaveAddress << ",0x" << std::hex << DeviceFw;
+            patchFile << BusNumber << ",0x" << std::hex << SlaveAddress << ",0x"
+                      << std::hex << DeviceFw;
+
+            devVersion = DeviceFw;
 
             if ((DeviceFw == PATCH_FW_1) || (DeviceFw == PATCH_FW_2))
             {
@@ -502,6 +505,8 @@ bool vr_update_renesas_gen3p5_patch::ValidateFirmware()
             patchFile.open(PATCH_VERSION_FILE, std::ios::app);
             patchFile << ",0x" << std::hex << DeviceFw << std::endl;
             patchFile.close();
+
+            devVersion = DeviceFw;
         }
     }
     return true;


### PR DESCRIPTION
For the Renesas patch update , display the VR version read from the device using i2c commands in the BMC webui instead of displaying the version values given by the user in the VR tar bundle.

Tested fields: Verified in Congo and Kenya platform.