### PR TITLE
Fix build failure and incorrect devVersion initialization

### DIFF
--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -169,7 +169,7 @@ class vr_update
     virtual bool crcCheckSum() = 0;
     virtual bool ValidateFirmware() = 0;
     bool CrcMatched;
-    uint32_t devVersion;
+    uint32_t devVersion = 0;
 };
 
 #endif

--- a/src/vr_update.cpp
+++ b/src/vr_update.cpp
@@ -18,6 +18,7 @@
 #include "vr_update_renesas_patch.hpp"
 #include "vr_update_xdpe_patch.hpp"
 #include "vr_update_fan2510xx.hpp"
+#include "vr_update_ism6636x.hpp"
 
 #define MODEL ("Model")
 #define SLAVE_ADDRESS ("SlaveAddress")


### PR DESCRIPTION
1. ISM6636 VR update: Fix build failure

2. The devVersion variable was not initialized during object creation, leading to undefined behavior and garbage values being displayed in the UI during config updates. This change sets devVersion to 0 during initialization to ensure consistent and predictable behavior.

Tested fields: Verified in Morocco system