### PR TITLE
Fix invalidate OTP for infineon XDPE VRs

### DIFF
--- a/inc/vr_update_infineon_xdpe.hpp
+++ b/inc/vr_update_infineon_xdpe.hpp
@@ -9,10 +9,12 @@
 #define GETCRCWAITTIME (20000)
 #define AVAILBYTEWAITTIME (1000)
 #define INVALBYTEWAITTIME (4000)
+#define SOAKTIME(100000)
 #define GETFWADDRWAITTIME (500)
 #define MINARGS (4)
 #define INT_255 (0xFF)
 #define TRIM_HEADER_CODE "00000002"
+#define INVALIDATE_ALL_OTP 0xfe
 
 /* Applicable Digital Controllers */
 #define PART1 (0x95)

--- a/src/vr_update_infineon_xdpe.cpp
+++ b/src/vr_update_infineon_xdpe.cpp
@@ -340,6 +340,8 @@ int invalidateOtp(uint8_t xv, uint8_t hc, int fd)
 {
     uint8_t wdata[MAXBUFFERSIZE];
     int rc = FAILURE;
+
+    sd_journal_print(LOG_INFO, "XV Code = %d hc code = %d \n", xv, hc);
     wdata[INDEX_0] = hc;
     wdata[INDEX_1] = xv;
     wdata[INDEX_2] = 0x00;
@@ -361,13 +363,15 @@ int invalidateOtp(uint8_t xv, uint8_t hc, int fd)
         return FAILURE;
     }
 
+    usleep(INVALBYTEWAITTIME);
+
     sd_journal_print(LOG_DEBUG, "Invalidate OTP Byte Write with cmd 0xfe\n");
     sd_journal_print(LOG_DEBUG, "0x%x\n", INVAL_BYTE);
 
     rc = i2c_smbus_write_byte_data(fd, BYTE_PREFIX, INVAL_BYTE);
 
-    // sleep for 4ms
-    usleep(INVALBYTEWAITTIME);
+    // sleep for 100ms
+    usleep(SOAKTIME);
 
     if (rc != SUCCESS)
     {
@@ -536,6 +540,25 @@ bool vr_update_infineon_xdpe::UpdateFirmware()
 
     std::vector<std::vector<std::string>> sections =
         parseCfgFile(ConfigFilePath);
+    int rc = FAILURE;
+    uint8_t rdata[MAXBUFFERSIZE] = {0};
+
+    rc = i2c_smbus_read_block_data(fd, DEVICE_ID_CMD, rdata);
+    if (rc > LENGTH_0)
+    {
+        sd_journal_print(LOG_INFO, "Product ID = 0x%x Revision = %d \n", rdata[INDEX_1], rdata[INDEX_0]);
+        if (rdata[INDEX_1] == PART7)
+	{
+	    exit_status = invalidateOtp(INVALIDATE_ALL_OTP, INVALIDATE_ALL_OTP, fd);
+	    if (exit_status != SUCCESS)
+            {
+                sd_journal_print(
+                    LOG_ERR,
+                    "Invalidate OTP Data has failed. Skipping other steps\n");
+                return false;
+            }
+        }
+    }
 
     // Trim header programming needs to be ignored according to Infineon FAE
     std::string trim_header = TRIM_HEADER_CODE;
@@ -548,17 +571,21 @@ bool vr_update_infineon_xdpe::UpdateFirmware()
             continue;
         }
 
-        std::vector<uint8_t> xvhc = formatDword(sections[i][INDEX_0]);
+	if(rdata[INDEX_1] == PART1 || rdata[INDEX_1] == PART2 ||
+            rdata[INDEX_1] == PART3 || rdata[INDEX_1] == PART4 ||
+            rdata[INDEX_1] == PART5 || rdata[INDEX_1] == PART6)
+	{
+            std::vector<uint8_t> xvhc = formatDword(sections[i][INDEX_0]);
 
-        exit_status = invalidateOtp(xvhc[INDEX_1], xvhc[INDEX_0], fd);
-        if (exit_status != SUCCESS)
-        {
-            sd_journal_print(
-                LOG_ERR,
-                "Invalidate OTP Data has failed. Skipping other steps\n");
-            return false;
-        }
-
+            exit_status = invalidateOtp(xvhc[INDEX_1], xvhc[INDEX_0], fd);
+            if (exit_status != SUCCESS)
+            {
+                sd_journal_print(
+                    LOG_ERR,
+                    "Invalidate OTP Data has failed. Skipping other steps\n");
+                return false;
+            }
+	}
         exit_status = writeDataToScratchpad(sections[i], fd);
         if (exit_status != SUCCESS)
         {


### PR DESCRIPTION
This fix handles invalidate OTP for infineon XDPE192xx and XDPE1D2xx individually based on the Product ID obtained from the VR. This enables reprogramming the entire config memory for XDPE1D2xx since any older sections not invalidated in OTP can affect the CRC calculation during VR firmware update.
