### PR TITLE
meta-amd:sp7:vr-update: Fix TDA VR address matching

### DIFF
--- a/config/vr-config-info
+++ b/config/vr-config-info
@@ -56,7 +56,7 @@ install_vr_platform_config()
        "5C" | "5D" | "5E" | "6C" | "6D" |"5F" | "60" ) #sh5 board_ids
           cp /usr/sbin/sh5-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
-       "80" | "81" | "86") #Congo board_ids
+       "80" | "81" | "86" | "88" | "89" | "8B" | "8C" | "8D" | "9E" | "B0") #Congo board_ids
           cp /usr/sbin/congo-vr.json "$vrConfigFolder/platform-vr.json"
        ;;
        "82" | "83" | "87" | "8A") #Morocco board_ids

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -793,8 +793,9 @@ int main(int argc, char* argv[])
                 {
                     std::string BundleSlaveAddr = bundleInterfaceObj.SlaveAddress[i];
                     uint16_t BundleSlaveAddress=std::stoul(BundleSlaveAddr, nullptr, BASE_16);
-                    if ((BundleSlaveAddress == SlaveAddress) &&
-                        (bundleInterfaceObj.UpdateStatus[i] == false))
+                    bool addressMatched = (BundleSlaveAddress == SlaveAddress) ||
+                      (BundleSlaveAddress == PmbusAddress);
+                    if (addressMatched && (bundleInterfaceObj.UpdateStatus[i] == false))
                     {
                         if (strcasecmp(bundleInterfaceObj.Processor[i].c_str(),
                                        Processor.c_str()) == SUCCESS)


### PR DESCRIPTION
Allow VR bundle address matching to use either the sideband I2C address or the PMBus address for TDA devices.

This fixes TDA VR update handling when the bundle contains the PMBus address while the updater internally uses the sideband address for device access.

Tested:
- Tested and verified on seagull-0016

Upstream-Status: Inappropriate