### PR TITLE
vr-update:sp7: Add Penguin-98bd SLT board ID support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,6 +132,7 @@ constexpr auto bundleVersionInterface =
 /*SP8 Venice SLT boards*/
 #define ROBIN 174     // 0xAE
 #define SANDPIPER 175 // 0xAF
+#define PENGUIN 186   // 0xBA
 #define DUCK 162      // 0xA2
 #define DUCK_1 163    // 0xA3
 #define DUCK_2 164    // 0xA4
@@ -478,7 +479,7 @@ bool PlatformIDValidation(std::string BoardName)
         }
         else if ((board_id == EAGLE) || (board_id == EAGLE_1) ||
                  (board_id == EAGLE_2) || (board_id == ROBIN) ||
-                 (board_id == SANDPIPER))
+                 (board_id == SANDPIPER) || (board_id == PENGUIN))
         {
             PlatformName = "Eagle";
         }


### PR DESCRIPTION
Add Penguin SLT board ID (0xBA) to platform validation and map it to the Eagle platform family.

This ensures VR update packages intended for Eagle platforms are correctly recognized on Eagle SLT systems.

Tested:

* Built vr-update successfully
* Verified on penguin

Upstream-Status: Inappropriate