### PR TITLE
vr-update:sp7: Add Pelican board ID support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,6 +135,7 @@ constexpr auto bundleVersionInterface =
 /*SP8 Venice SLT boards*/
 #define ROBIN 174     // 0xAE
 #define SANDPIPER 175 // 0xAF
+#define PELICAN 185   // 0xB9
 #define DUCK 162      // 0xA2
 #define DUCK_1 163    // 0xA3
 #define DUCK_2 164    // 0xA4
@@ -483,7 +484,7 @@ bool PlatformIDValidation(std::string BoardName)
         }
         else if ((board_id == EAGLE) || (board_id == EAGLE_1) ||
                  (board_id == EAGLE_2) || (board_id == ROBIN) ||
-                 (board_id == SANDPIPER))
+                 (board_id == SANDPIPER) || (board_id == PELICAN))
         {
             PlatformName = "Eagle";
         }


### PR DESCRIPTION
Add Pelican board ID 0xB9 to platform validation
so it is recognized correctly during VR update.

Tested:

Built vr-update successfully

Upstream-Status: Inappropriate