### PR TITLE
vr-update: safe hex parsing and bundle error logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -534,6 +534,51 @@ inline void trim(std::string& str)
               str.end());
 }
 
+static bool parseHexU16(const std::string& str, uint16_t& out,
+                        const char* fieldName)
+{
+    if (str.empty())
+    {
+        sd_journal_print(LOG_ERR, "VR bundle: empty %s", fieldName);
+        return false;
+    }
+    try
+    {
+        unsigned long val = std::stoul(str, nullptr, BASE_16);
+        out = static_cast<uint16_t>(val);
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        sd_journal_print(LOG_ERR,
+                         "VR bundle: invalid hex in %s '%s': %s",
+                         fieldName, str.c_str(), e.what());
+        return false;
+    }
+}
+
+static bool parseHexU32(const std::string& str, uint32_t& out,
+                        const char* fieldName)
+{
+    if (str.empty())
+    {
+        sd_journal_print(LOG_ERR, "VR bundle: empty %s", fieldName);
+        return false;
+    }
+    try
+    {
+        out = static_cast<uint32_t>(std::stoul(str, nullptr, BASE_16));
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        sd_journal_print(LOG_ERR,
+                         "VR bundle: invalid hex in %s '%s': %s",
+                         fieldName, str.c_str(), e.what());
+        return false;
+    }
+}
+
 int main(int argc, char* argv[])
 {
     int ret = FAILURE;
@@ -649,14 +694,18 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have model number. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
-                if (record.contains("SlaveAddress"))
+                if (record.contains("SlaveAddress") &&
+                    record["SlaveAddress"].is_string())
                 {
                     SlaveAddr = record["SlaveAddress"];
 
-                    SlaveAddress = std::stoul(SlaveAddr, nullptr, BASE_16);
+                    if (!parseHexU16(SlaveAddr, SlaveAddress, "SlaveAddress"))
+                    {
+                        return FAILURE;
+                    }
                     if (std::filesystem::exists(VR_PLATFORM_FILE))
                     {
                         std::ifstream vr_json_file(VR_PLATFORM_FILE);
@@ -667,16 +716,27 @@ int main(int argc, char* argv[])
                         {
                             std::string PlatformSlaveAddr =
                                 platform_record["SlaveAddress"];
-                            uint16_t PlatformSlaveAddress = std::stoul(
-                                PlatformSlaveAddr, nullptr, BASE_16);
+                            uint16_t PlatformSlaveAddress = 0;
                             uint16_t PlatformPmbusAddress = 0;
+
+                            if (!platform_record["SlaveAddress"].is_string() ||
+                                !parseHexU16(PlatformSlaveAddr,
+                                             PlatformSlaveAddress,
+                                             "Platform SlaveAddress"))
+                            {
+                                continue;
+                            }
 
                             if (platform_record.contains("PmbusAddress"))
                             {
                                 std::string PmbusAddr =
                                     platform_record["PmbusAddress"];
-                                PlatformPmbusAddress =
-                                    std::stoul(PmbusAddr, nullptr, BASE_16);
+                                if (!platform_record["PmbusAddress"].is_string() ||
+                                    !parseHexU16(PmbusAddr, PlatformPmbusAddress,
+                                                 "PmbusAddress"))
+                                {
+                                    continue;
+                                }
                             }
 
                             if (PlatformSlaveAddress == SlaveAddress ||
@@ -695,13 +755,16 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have slave address. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
-                if (record.contains("CRC"))
+                if (record.contains("CRC") && record["CRC"].is_string())
                 {
                     CrcConfig = record["CRC"];
-                    Crc = std::stoul(CrcConfig, nullptr, BASE_16);
+                    if (!parseHexU32(CrcConfig, Crc, "CRC"))
+                    {
+                        return FAILURE;
+                    }
                 }
 
                 if (record.contains("Processor"))
@@ -713,7 +776,7 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have Processor details. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
                 if (record.contains("BoardName"))
@@ -725,7 +788,7 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have BoadrdName details. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
                 if (record.contains("ConfigFile"))
@@ -738,7 +801,7 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have ConfigFile details. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
                 if (record.contains("ConfigFile"))
@@ -767,7 +830,7 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have ConfigFile details. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
                 if (record.contains("Version"))
@@ -784,7 +847,7 @@ int main(int argc, char* argv[])
                     sd_journal_print(
                         LOG_ERR,
                         "Json file doesnt have UpdateType details. Update aborted\n");
-                    return false;
+                    return FAILURE;
                 }
 
                 if (record.contains("Revision"))
@@ -800,7 +863,7 @@ int main(int argc, char* argv[])
 
                 if (PlatformIDValidation(BoardName) == false)
                 {
-                    return false;
+                    return FAILURE;
                 }
 
                 sd_journal_print(LOG_INFO,
@@ -815,7 +878,12 @@ int main(int argc, char* argv[])
                 for (int i = 0; i < bundleInterfaceObj.SlaveAddress.size(); i++)
                 {
                     std::string BundleSlaveAddr = bundleInterfaceObj.SlaveAddress[i];
-                    uint16_t BundleSlaveAddress=std::stoul(BundleSlaveAddr, nullptr, BASE_16);
+                    uint16_t BundleSlaveAddress = 0;
+                    if (!parseHexU16(BundleSlaveAddr, BundleSlaveAddress,
+                                     "Bundle SlaveAddress"))
+                    {
+                        continue;
+                    }
                     bool addressMatched = (BundleSlaveAddress == SlaveAddress) ||
                       (BundleSlaveAddress == PmbusAddress);
                     if (addressMatched && (bundleInterfaceObj.UpdateStatus[i] == false))


### PR DESCRIPTION
Guard hex string conversions in the VR bundle path against empty and invalid values. Return FAILURE on bundle validation errors and log actionable messages to journald.

Tested: 
- Empty SlaveAddress: logged error, exit 255
- Invalid CRC 'ZZZZ': logged error, exit 255
- Missing ConfigFile: logged error, exit 255