### PR TITLE
vr-update: Fixing the VR Config Update Application

### DIFF
--- a/inc/vr_update.hpp
+++ b/inc/vr_update.hpp
@@ -169,6 +169,7 @@ class vr_update
     virtual bool UpdateFirmware() = 0;
     virtual bool crcCheckSum() = 0;
     virtual bool ValidateFirmware() = 0;
+    bool ReadbackVerify();
     bool CrcMatched;
     uint32_t devVersion = 0;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,7 +186,6 @@ int vrUpdate(std::string Model, uint16_t SlaveAddress, uint32_t Crc,
 
         if (rc != true)
         {
-            sd_journal_print(LOG_ERR, "Unable to find the bus number\n");
             ret = FAILURE;
             goto Clean;
         }
@@ -232,6 +231,14 @@ int vrUpdate(std::string Model, uint16_t SlaveAddress, uint32_t Crc,
             ret = FAILURE;
             goto Clean;
         }
+
+        rc = vr_update_obj->ReadbackVerify();
+        if (rc != true)
+        {
+            ret = FAILURE;
+            goto Clean;
+        }
+        
         ret = SUCCESS;
     Clean:
         vr_update_obj->closeI2cDevice();
@@ -804,13 +811,32 @@ int main(int argc, char* argv[])
                 }
 
                 sd_journal_print(LOG_INFO,
-                                 "Updating VR for the Slave Address = 0x%x",
-                                 SlaveAddress);
+                                 "Updating %s VR for the Slave Address = 0x%x",
+                                  Processor.c_str(),SlaveAddress);
 
                 ret = vrUpdate(Model, SlaveAddress, Crc, &deviceVersion,
                                Processor, configFilePath, UpdateType,
                                &CrcMatched, Revision, PmbusAddress,
                                configFilePathArr);
+
+                if (ret != SUCCESS && CrcMatched == false)
+                {
+                    rc = FAILURE;
+                }
+
+                if (ret == SUCCESS)
+                {
+                    sd_journal_print(LOG_INFO,
+                        "VR update completed for %s at slave address 0x%x.",
+                        Processor.c_str(),SlaveAddress);
+                }
+
+                else if (CrcMatched == true)
+                {
+                    sd_journal_print(LOG_INFO,
+                        "VR already up to date for %s at slave address 0x%x.",
+                        Processor.c_str(),SlaveAddress);
+                }
 
                 for (int i = 0; i < bundleInterfaceObj.SlaveAddress.size(); i++)
                 {

--- a/src/vr_update.cpp
+++ b/src/vr_update.cpp
@@ -183,19 +183,38 @@ bool vr_update::findBusNumber()
 
         if (slaveDevice.empty())
         {
+            sd_journal_print(LOG_ERR,
+                "VR update failed: no device found for %s at slave address 0x%x.",
+                Processor.c_str(),SlaveAddress);
             return false;
         }
         std::sort(slaveDevice.begin(), slaveDevice.end());
 
-        if ((Processor.compare(SOCKET_0) == SUCCESS) ||
-            (slaveDevice.size() == 1))
+        int index = FAILURE;
+        if ((Processor.compare(SOCKET_0) == SUCCESS))
         {
-            DeviceName = slaveDevice[INDEX_0];
+            index = INDEX_0;
         }
         else if (Processor.compare(SOCKET_1) == SUCCESS)
         {
-            DeviceName = slaveDevice[INDEX_1];
+            index = INDEX_1;
         }
+        else 
+        {
+            index = INDEX_0;
+        }
+
+        if(index >= static_cast<int>(slaveDevice.size()))
+        {
+            sd_journal_print(LOG_ERR,
+                "VR update failed: device for %s at slave address 0x%x not found "
+                "(found %zu device(s)). Aborting to avoid programming the wrong socket",
+                Processor.c_str(),SlaveAddress,slaveDevice.size());
+            return false;
+        }
+
+        DeviceName = slaveDevice[index];
+
         size_t found = DeviceName.find("-");
         BusNumber = std::stoi(DeviceName.substr(0, found));
     }
@@ -213,6 +232,32 @@ bool vr_update::findBusNumber()
     {
         return false;
     }
+}
+
+bool vr_update::ReadbackVerify()
+{
+    sd_journal_print(LOG_INFO,
+        "Readback verification: reading back %s VR at slave address 0x%x",
+         Processor.c_str(),SlaveAddress);
+    
+    usleep(SLEEP_1);
+    
+    crcCheckSum();
+
+    if(CrcMatched == true)
+    {
+        sd_journal_print(LOG_INFO,
+            "Readback Passed: %s VR at slave address 0x%x -programmed firmware verified",
+            Processor.c_str(),SlaveAddress);
+        return true;
+    }
+    else
+    {
+        sd_journal_print(LOG_ERR,
+            "Readback Failed: %s VR at slave address 0x%x -device CRC does not match programmed image",
+            Processor.c_str(),SlaveAddress);
+    }
+    return false;
 }
 
 bool vr_update::openI2cDevice()


### PR DESCRIPTION
On 2P platforms the VR update application fell back to another socket's I2C bus when the target socket device was missing. Abort the update with a clear error message instead of falling back to different socket

Tested: on sp7
Verified VR configuration updates and error handling behaviour.